### PR TITLE
Setup improvements

### DIFF
--- a/bin/rebuild_db.php
+++ b/bin/rebuild_db.php
@@ -1,7 +1,8 @@
+#!/usr/bin/env php
 <?php
 
 // determine where the sqlite DB will go
-$dir = __DIR__.'/oauth.sqlite';
+$dir = dirname(__DIR__) . '/data/oauth.sqlite';
 
 // remove sqlite file if it exists
 if (file_exists($dir)) {
@@ -15,8 +16,8 @@ $db->exec('CREATE TABLE oauth_clients (client_id TEXT, client_secret TEXT, redir
 $db->exec('CREATE TABLE oauth_access_tokens (access_token TEXT, client_id TEXT, user_id TEXT, expires TIMESTAMP, scope TEXT)');
 $db->exec('CREATE TABLE oauth_authorization_codes (authorization_code TEXT, client_id TEXT, user_id TEXT, redirect_uri TEXT, expires TIMESTAMP, scope TEXT)');
 
-// add test data
-$db->exec('INSERT INTO oauth_clients (client_id, client_secret) VALUES ("demoapp", "demopass")');
+$db->exec('CREATE TABLE oauth_refresh_tokens (refresh_token TEXT, client_id TEXT, user_id TEXT, expires TIMESTAMP, scope TEXT)');
+$db->exec('INSERT INTO oauth_clients (client_id, client_secret, redirect_uri) VALUES ("demoapp", "demopass", "http://localhost/demo/authorized")');
 
 chmod($dir, 0777);
 // $db->exec('INSERT INTO oauth_access_tokens (access_token, client_id) VALUES ("testtoken", "Some Client")');

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "silex/silex": "1.0.*",
         "symfony/twig-bridge": "2.1.*",
-        "bshaffer/oauth2-server-php": "dev-develop",
+        "bshaffer/oauth2-server-php": "dev-master",
         "bshaffer/oauth2-server-httpfoundation-bridge": "dev-master"
     },
     "autoload" : {


### PR DESCRIPTION
We've been trying to get this code running and here are a few improvements up front.

We are also in the process of trying to figure out why the final request to `/grant` times out - no luck yet and probably also a PR for [bshaffer/oauth2-server-php](https://github.com/bshaffer/oauth2-server-php).

---
### Changelog

Switch to dev-master (since dev-develop contains bugs).

rebuild_db.php
- move rebuild_db.php to a bin directory and adjust the path to the database
- make it executable and add a shebang

Fixes by @dazz:
- Add missing table to rebuild_db.php script.
- Add some sample data (note: the code requires to run on port 80 - somewhere.)

The piece about port 80 may or may not be a bug. It took me a while to debug this with the custom curl code in there and it just said that it timed out while trying to request something on `localhost:80` and I had the code running on `localhost:8002` (through PHP's internal web server).
