### PR TITLE
Replace hard-coded port 80 by $_SERVER['SERVER_PORT']

### DIFF
--- a/src/OAuth2Demo/Shared/Curl.php
+++ b/src/OAuth2Demo/Shared/Curl.php
@@ -10,7 +10,7 @@ class Curl
     {
         $this->options = array_merge(array(
             'debug'      => false,
-            'http_port'  => '80',
+            'http_port'  => is_numeric($_SERVER['SERVER_PORT']) ? intval($_SERVER['SERVER_PORT']) : 80,
             'user_agent' => 'PHP-curl-client (https://github.com/bshaffer/oauth2-demo-php)',
             'timeout'    => 20,
             'curlopts'   => null,


### PR DESCRIPTION
In order for the demo to work out of the box on a test server (often on a port different from 80 such as 8080), here is a suggestion to default to $_SERVER['SERVER_PORT'] instead of a hard-coded port 80.
Of course, the explicit configuration in parameters.json still has precedence.
