### PR TITLE
Error in SQLite PDO DSN

### DIFF
--- a/data/rebuild_db.php
+++ b/data/rebuild_db.php
@@ -16,7 +16,7 @@ if (!is_writable(__DIR__)) {
 }
 
 // rebuild the DB
-$db = new PDO(sprintf('sqlite://%s', $dbfile));
+$db = new PDO(sprintf('sqlite:%s', $dbfile));
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->exec('CREATE TABLE oauth_clients (client_id TEXT, client_secret TEXT, redirect_uri TEXT)');
 $db->exec('CREATE TABLE oauth_access_tokens (access_token TEXT, client_id TEXT, user_id TEXT, expires TIMESTAMP, scope TEXT)');


### PR DESCRIPTION
The SQLite PDO DSN is "sqlite:", not "sqlite://"
http://www.php.net/manual/ref.pdo-sqlite.connection.php
While the later seems to work on Linux, it fails on Windows.
The proper syntax proposed by this patch works on both platforms.
