### PR TITLE
Access token missing for remote resource request

### DIFF
--- a/src/OAuth2Demo/Client/Controllers/RequestResource.php
+++ b/src/OAuth2Demo/Client/Controllers/RequestResource.php
@@ -29,7 +29,9 @@ class RequestResource
         $endpoint = 0 === strpos($apiRoute, 'http') ? $apiRoute : $urlgen->generate($apiRoute, $config['resource_params'], true);
 
         // make the resource request and decode the json response
-        $response = $http->get($endpoint, null, $config['http_options'])->send();
+        $request = $http->get($endpoint, null, $config['http_options']);
+        $request->getQuery()->set('access_token', $token);
+        $response = $request->send();
         $json = json_decode((string) $response->getBody(), true);
 
         $resource_uri = sprintf('%s%saccess_token=%s', $endpoint, false === strpos($endpoint, '?') ? '?' : '&', $token);


### PR DESCRIPTION
Thanks for the great work on this project @bshaffer it's made implementing your oauth server (which is great), very simple.

I did find when testing it with a remote server that the final resource request fails with a forbidden due to not passing over the access token.

This seems to fix that and doesn't bork it when using the local server.

Thanks
Tom
