### PR TITLE
Fix to make implicit authorization flow to work

### DIFF
--- a/views/client/show_implicit_token.twig
+++ b/views/client/show_implicit_token.twig
@@ -26,7 +26,7 @@
             Now use this token to make a request to the OAuth2.0 Server's APIs:
         </p>
 
-        <a class="button" href="{{ path('request_resource') }}" onclick="this.href += '?token='+tokenParams.access_token;">make a resource request</a>
+        <a class="button" href="{{ path('request_resource') }}" onclick="this.href += '?token='+getAccessToken();">make a resource request</a>
 
         <div class="help"><em>This token can now be used multiple times to make API requests for this user.</em></div>
 


### PR DESCRIPTION
Currently implicit authorization can not be fully tested using the client as it is referencing an undefined variable. This pull request fixes it to refer to the function instead
