### PR TITLE
Update composer.json to use older version of Silex.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "silex/silex": "dev-master",
+        "silex/silex": "1.2.*@dev",
         "symfony/twig-bridge": "2.1.*",
         "bshaffer/oauth2-server-php": "v1.0",
         "bshaffer/oauth2-server-httpfoundation-bridge": "v1.0",


### PR DESCRIPTION
The Silex master branch is on 2.0 now, which is incompatible with oauth2-demo-php. Setting Silex version string to 1.2.*@dev.
