### PR TITLE
Add example usage of refresh token.

### DIFF
--- a/src/OAuth2Demo/Client/Controllers/RequestToken.php
+++ b/src/OAuth2Demo/Client/Controllers/RequestToken.php
@@ -10,6 +10,7 @@ class RequestToken
     {
         $routing->get('/client/request_token/authorization_code', array(new self(), 'requestTokenWithAuthCode'))->bind('request_token_with_authcode');
         $routing->get('/client/request_token/user_credentials', array(new self(), 'requestTokenWithUserCredentials'))->bind('request_token_with_usercredentials');
+        $routing->get('/client/request_token/refresh_token', array(new self(), 'requestTokenWithRefreshToken'))->bind('request_token_with_refresh_token');
 
     }
 
@@ -41,7 +42,7 @@ class RequestToken
 
         // if it is succesful, display the token in our app
         if (isset($json['access_token'])) {
-            return $twig->render('client/show_access_token.twig', array('token' => $json['access_token']));
+            return $twig->render('client/show_access_token.twig', array('response' => $json));
         }
 
         return $twig->render('client/failed_token_request.twig', array('response' => $json ? $json : $response));
@@ -76,7 +77,40 @@ class RequestToken
 
         // if it is succesful, display the token in our app
         if (isset($json['access_token'])) {
-            return $twig->render('client/show_access_token.twig', array('token' => $json['access_token']));
+            return $twig->render('client/show_access_token.twig', array('response' => $json));
+        }
+
+        return $twig->render('client/failed_token_request.twig', array('response' => $json ? $json : $response));
+    }
+
+    public function requestTokenWithRefreshToken(Application $app)
+    {
+        $twig   = $app['twig'];          // used to render twig templates
+        $config = $app['parameters'];    // the configuration for the current oauth implementation
+        $urlgen = $app['url_generator']; // generates URLs based on our routing
+        $http   = $app['http_client'];   // simple class used to make http requests
+
+        $refreshToken = $app['request']->get('refresh_token');
+
+        // exchange user credentials for access token
+        $query = array(
+            'grant_type'    => 'refresh_token',
+            'client_id'     => $config['client_id'],
+            'client_secret' => $config['client_secret'],
+            'refresh_token' => $refreshToken,
+        );
+
+        // determine the token endpoint to call based on our config (do this somewhere else?)
+        $grantRoute = $config['token_route'];
+        $endpoint = 0 === strpos($grantRoute, 'http') ? $grantRoute : $urlgen->generate($grantRoute, array(), true);
+
+        // make the token request via http and decode the json response
+        $response = $http->post($endpoint, null, $query, $config['http_options'])->send();
+        $json = json_decode((string) $response->getBody(), true);
+
+        // if it is succesful, display the token in our app
+        if (isset($json['access_token'])) {
+            return $twig->render('client/show_access_token.twig', array('response' => $json));
         }
 
         return $twig->render('client/failed_token_request.twig', array('response' => $json ? $json : $response));

--- a/src/OAuth2Demo/Server/Server.php
+++ b/src/OAuth2Demo/Server/Server.php
@@ -9,6 +9,7 @@ use OAuth2\Server as OAuth2Server;
 use OAuth2\Storage\Pdo;
 use OAuth2\GrantType\AuthorizationCode;
 use OAuth2\GrantType\UserCredentials;
+use OAuth2\GrantType\RefreshToken;
 
 class Server implements ControllerProviderInterface
 {
@@ -29,6 +30,9 @@ class Server implements ControllerProviderInterface
         $grantTypes = array(
             'authorization_code' => new AuthorizationCode($storage),
             'user_credentials'   => new UserCredentials($storage),
+            'refresh_token'      => new RefreshToken($storage, array(
+                'always_issue_new_refresh_token' => true,
+            )),
         );
 
         // instantiate the oauth server

--- a/views/client/show_access_token.twig
+++ b/views/client/show_access_token.twig
@@ -8,10 +8,6 @@
     <div class="help"><em>Expires in {{ response.expires_in }} seconds</em></div>
     {% endif %}
 
-    {% if response.refresh_token %}
-    <pre><code>  Refresh Token: {{ response.refresh_token }}  </code></pre>
-    {% endif %}
-
     <p>
         Now use this token to make a request to the OAuth2.0 Server's APIs:
     </p>
@@ -24,13 +20,17 @@
     <hr>
     <br>
 
-    <p>
-        Or you can use the refresh token to renew your access token when it expires:
-    </p>
+    {% if response.refresh_token %}
+        <p>
+            Or you can use the refresh token to renew your access token when it expires:
+        </p>
 
-    <a class="button" href="{{ path('request_token_with_refresh_token', { 'refresh_token': response.refresh_token }) }}">renew your access token</a>
+        <pre><code>  Refresh Token: {{ response.refresh_token }}  </code></pre>
 
-    <div class="help"><em>The refresh token can be used both when the access token has expired and when it hasn't.</em></div>
+        <a class="button" href="{{ path('request_token_with_refresh_token', { 'refresh_token': response.refresh_token }) }}">renew your access token</a>
+
+        <div class="help"><em>The refresh token can be used both when the access token has expired and when it hasn't.</em></div>
+    {% endif %}
 
     <a href="{{ path('homepage') }}">back</a>
 {% endblock %}

--- a/views/client/show_access_token.twig
+++ b/views/client/show_access_token.twig
@@ -2,15 +2,35 @@
 
 {% block content %}
     <h3>Token Retrieved!</h3>
-    <pre><code>  Access Token: {{ token }}  </code></pre>
+    <pre><code>  Access Token: {{ response.access_token }}  </code></pre>
+
+    {% if response.expires_in %}
+    <div class="help"><em>Expires in {{ response.expires_in }} seconds</em></div>
+    {% endif %}
+
+    {% if response.refresh_token %}
+    <pre><code>  Refresh Token: {{ response.refresh_token }}  </code></pre>
+    {% endif %}
 
     <p>
         Now use this token to make a request to the OAuth2.0 Server's APIs:
     </p>
 
-    <a class="button" href="{{ path('request_resource', { 'token': token }) }}">make a resource request</a>
+    <a class="button" href="{{ path('request_resource', { 'token': response.access_token }) }}">make a resource request</a>
 
     <div class="help"><em>This token can now be used multiple times to make API requests for this user.</em></div>
+
+    <br>
+    <hr>
+    <br>
+
+    <p>
+        Or you can use the refresh token to renew your access token when it expires:
+    </p>
+
+    <a class="button" href="{{ path('request_token_with_refresh_token', { 'refresh_token': response.refresh_token }) }}">renew your access token</a>
+
+    <div class="help"><em>The refresh token can be used both when the access token has expired and when it hasn't.</em></div>
 
     <a href="{{ path('homepage') }}">back</a>
 {% endblock %}


### PR DESCRIPTION
Support for the refresh token grant type is added to the client controllers
and the views. It is presented to the user with ability to renew the
access token via the refresh token.