### PR TITLE
comma missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ you want to test against:
       "authorize_route": "https://myapp.com/authorize",
       "resource_route": "https://api.myapp.com/profile",
       "resource_method": "POST",
-      "resource_params": { "debug": true }
+      "resource_params": { "debug": true },
       "curl_options": { "http_port": 443, "verifyssl": false }
     }
 


### PR DESCRIPTION
Fatal error: Uncaught exception 'Exception' with message 'unable to parse parameters file: /var/www/html/oauth2-demo-php/src/OAuth2Demo/Client/../../../data/parameters.json' in /var/www/html/oauth2-demo-php/src/OAuth2Demo/Client/Client.php:66 Stack trace: #0 /var/www/html/oauth2-demo-php/src/OAuth2Demo/Client/Client.php(28): OAuth2Demo\Client\Client->loadParameters(Object(Silex\Application)) #1 /var/www/html/oauth2-demo-php/src/OAuth2Demo/Client/Client.php(40): OAuth2Demo\Client\Client->setup(Object(Silex\Application)) #2 /var/www/html/oauth2-demo-php/vendor/silex/silex/src/Silex/Application.php(497): OAuth2Demo\Client\Client->connect(Object(Silex\Application)) #3 /var/www/html/oauth2-demo-php/web/index.php(19): Silex\Application->mount('/', Object(OAuth2Demo\Client\Client)) #4 {main} thrown in /var/www/html/oauth2-demo-php/src/OAuth2Demo/Client/Client.php on line 66