### PR TITLE
fixed duplicate adding of access_token to request url on local server

### DIFF
--- a/src/OAuth2Demo/Client/Controllers/RequestResource.php
+++ b/src/OAuth2Demo/Client/Controllers/RequestResource.php
@@ -21,12 +21,9 @@ class RequestResource
         // pull the token from the request
         $token = $app['request']->get('token');
 
-        // make the resource request with the token in the request body
-        $config['resource_params']['access_token'] = $token;
-
         // determine the resource endpoint to call based on our config (do this somewhere else?)
         $apiRoute = $config['resource_route'];
-        $endpoint = 0 === strpos($apiRoute, 'http') ? $apiRoute : $urlgen->generate($apiRoute, $config['resource_params'], true);
+        $endpoint = 0 === strpos($apiRoute, 'http') ? $apiRoute : $urlgen->generate($apiRoute, array(), true);
 
         // make the resource request and decode the json response
         $request = $http->get($endpoint, null, $config['http_options']);
@@ -34,8 +31,6 @@ class RequestResource
         $response = $request->send();
         $json = json_decode((string) $response->getBody(), true);
 
-        $resource_uri = sprintf('%s%saccess_token=%s', $endpoint, false === strpos($endpoint, '?') ? '?' : '&', $token);
-
-        return $twig->render('client/show_resource.twig', array('response' => $json ? $json : $response, 'resource_uri' => $resource_uri));
+        return $twig->render('client/show_resource.twig', array('response' => $json ? $json : $response, 'resource_uri' => $request->getUrl()));
     }
 }


### PR DESCRIPTION
This is a fix for the issue from #56 with `access_token`. Problem was on local server the token is added 3 times to the route and 2 of them are shown in the view as Queryparams.
With this fix the Uri for local and remote server are "generated" clean and token is added in Guzzle Request, so it is always added once.
