### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This is very useful when testing your application in production
 >  Note: The curl options are set to ignore an SSL certificate, and the `resource_params` define a fictional debug parameter.
 >  These are not required for your APIs, but is meant as an example what can be done with the configuration
 
-###Test in multiple environments
+### Test in multiple environments
 
 In addition, you can create multiple environments using the parameters.json file, and switch between them:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
